### PR TITLE
update gemspec license and authors

### DIFF
--- a/api_client.gemspec
+++ b/api_client.gemspec
@@ -5,11 +5,12 @@ require "api_client/version"
 Gem::Specification.new do |s|
   s.name        = "api_client"
   s.version     = ApiClient::VERSION
-  s.authors     = ["Marcin Bunsch"]
-  s.email       = ["marcin@futuresimple.com"]
+  s.authors     = ["Zendesk"]
+  s.email       = ["opensource@zendesk.com"]
   s.homepage    = "https://github.com/futuresimple/api_client"
   s.summary     = %q{API client builder}
   s.description = %q{API client builder}
+  s.license     = "Apache License Version 2.0"
 
   s.rubyforge_project = "api_client"
 

--- a/lib/api_client/version.rb
+++ b/lib/api_client/version.rb
@@ -1,3 +1,3 @@
 module ApiClient
-  VERSION = '0.5.23'
+  VERSION = '0.5.24'
 end


### PR DESCRIPTION
update gemspec with updated license to Apache 2 and use company wide author and email Zendesk and opensource@zendesk.com. to release in rubygems patch version is bumped.